### PR TITLE
FEAT: Handle recent boards display

### DIFF
--- a/angular_front/src/app/components/navbar/navbar.component.html
+++ b/angular_front/src/app/components/navbar/navbar.component.html
@@ -43,7 +43,19 @@
                             Recent
                         </button>
                         <ul class="dropdown-menu">
-                            <li><a class="dropdown-item">No recent board</a></li>
+                            <li *ngFor="let recent of this.recentBoards">
+                                <button class="dropdown-item" (click)="goToBoard(recent.workspaceId, recent.id)">
+                                    <img
+                                        [style.background-image]="'url(' + recent.picture + ')'"
+                                        [style.background-color]="recent.color"
+                                        [style.background-size]="'cover'"
+                                        class="rounded"
+                                        style="width: 30px; height: 30px;"
+                                    >
+                                    {{ recent.name }}
+                                </button>
+                            </li>
+                            <li *ngIf="this.recentBoards.length == 0"><a class="dropdown-item">No recent board</a></li>
                         </ul>
                     </div>
                 </li>

--- a/angular_front/src/app/components/navbar/navbar.component.ts
+++ b/angular_front/src/app/components/navbar/navbar.component.ts
@@ -26,6 +26,7 @@ export class NavbarComponent {
 
     workspaces: any[] = [];
     starredBoards: any[] = [];
+    recentBoards: any[] = [];
     boards: any[] = [];
 
     notifications: any[] = [];
@@ -90,6 +91,20 @@ export class NavbarComponent {
                                 if (!this.boards.some(b => b.id === board.id && b.workspaceId === workspace.id)) {
                                     this.boards.push({...board, workspaceId: workspace.id});
                                     this.boardSearchResults.push({...board, workspaceId: workspace.id});
+                                }
+                                if (!this.recentBoards.some(recentBoard => recentBoard.id === board.id ) && board.lastOpen) {
+                                    this.recentBoards.push({
+                                        ...board,
+                                        workspaceId: workspace.id
+                                    });
+                                    this.recentBoards.sort((a, b) => {
+                                        const timeA = a.lastOpen.seconds * 1000 + a.lastOpen.nanoseconds / 1e6;
+                                        const timeB = b.lastOpen.seconds * 1000 + b.lastOpen.nanoseconds / 1e6;
+                                        return timeB - timeA;
+                                    });
+                                    if (this.recentBoards.length > 4) {
+                                        this.recentBoards = this.recentBoards.slice(0, 4);
+                                    }
                                 }
                             });
                         });

--- a/angular_front/src/app/pages/board/board.component.ts
+++ b/angular_front/src/app/pages/board/board.component.ts
@@ -62,6 +62,9 @@ export class BoardComponent {
     ngOnInit() {
         this.workspaceId = this.route.snapshot.paramMap.get('workspaceId');
         this.boardId = this.route.snapshot.paramMap.get('boardId');
+        if (this.workspaceId && this.boardId) {
+            this.svBoard.setRecentOpen(this.workspaceId, this.boardId);
+        }
         this.refreshLists();
         this.subscription = this.svOpenCard.isOpenCard$.subscribe(open => {
             this.isOpenCard = open;

--- a/angular_front/src/app/pages/home/home.component.html
+++ b/angular_front/src/app/pages/home/home.component.html
@@ -39,7 +39,18 @@
             <!-- Recently Viewed Section -->
             <div>
                 <h2 class="fw-bold"><i class="bi bi-clock"></i> Recently viewed</h2>
-                <img src="https://via.placeholder.com/195x100" alt="Trello Board Thumbnail">
+                <div class="row row-cols-auto col gap-2">
+                    <div *ngFor="let recent of this.recentBoards" class="d-flex justify-content-center align-items-center mb-3">
+                        <button
+                            (click)="this.goToBoard(recent.workspaceId, recent.id)"
+                            class="btn btn-light board-button"
+                            style="height: 7rem; width: 13rem;"
+                            [style.background-color]="recent.color">
+                            <img *ngIf="recent.picture" [src]="recent.picture" class="w-100 h-100 board-image">
+                            <p>{{ recent.name }}</p>
+                        </button>
+                    </div>
+                </div>
             </div>
 
             <!-- Your Workspaces Section -->

--- a/angular_front/src/app/pages/home/home.component.ts
+++ b/angular_front/src/app/pages/home/home.component.ts
@@ -27,6 +27,7 @@ export class HomeComponent {
     workspacePictureToAdd: string = "";
 
     starredBoards: any[] = [];
+    recentBoards: any[] = [];
 
     backgroundColors: string[] = [
         "#b9f3db", "#f8e5a0", "#fedec9", "#fed5d1", "#ded8fc",
@@ -62,12 +63,27 @@ export class HomeComponent {
                                         });
                                     }
                                 }
+                                if (!this.recentBoards.some(recentBoard => recentBoard.id === board.id ) && board.lastOpen) {
+                                    this.recentBoards.push({
+                                        ...board,
+                                        workspaceId: workspace.id
+                                    });
+                                    this.recentBoards.sort((a, b) => {
+                                        const timeA = a.lastOpen.seconds * 1000 + a.lastOpen.nanoseconds / 1e6;
+                                        const timeB = b.lastOpen.seconds * 1000 + b.lastOpen.nanoseconds / 1e6;
+                                        return timeB - timeA;
+                                    });
+                                    if (this.recentBoards.length > 4) {
+                                        this.recentBoards = this.recentBoards.slice(0, 4);
+                                    }
+                                }
                             });
                         });
                     });
                 });
             }
         });
+        console.log(this.recentBoards);
     }
 
 

--- a/angular_front/src/app/services/firebase-boards/firebase-boards.service.ts
+++ b/angular_front/src/app/services/firebase-boards/firebase-boards.service.ts
@@ -93,4 +93,15 @@ export class FirebaseBoardsService {
                 stars: firebase.firestore.FieldValue.arrayRemove(userId)
             });
     }
+
+    setRecentOpen(workspaceId: string, boardId: string) {
+        // Set the date of the last open board
+        return this.fs.collection(this.workspaceCollection)
+            .doc(workspaceId)
+            .collection('boards')
+            .doc(boardId)
+            .update({
+                lastOpen: new Date()
+            });
+    }
 }


### PR DESCRIPTION
Users can now access to their recent boards in home or in the navbar.

![image](https://github.com/user-attachments/assets/894f26ea-8b2f-474e-95fa-c1102846801a)
